### PR TITLE
Add retries to the button container select (fix)

### DIFF
--- a/src/anilistOverrides/addButton.ts
+++ b/src/anilistOverrides/addButton.ts
@@ -1,5 +1,5 @@
-import { fetchMalId } from "../api/api";
-import { createMALButton } from "../components/MalButton/button";
+import { fetchMalId } from '../api/api';
+import { createMALButton } from '../components/MalButton/button';
 
 export async function addButton(anilistId: string) {
   // const buttonContainer = document.querySelector(
@@ -8,19 +8,19 @@ export async function addButton(anilistId: string) {
   const TIMEOUT = 300;
   let MAX_RETRIES = 5;
 
-  const buttonContainer = document.querySelector("div.actions");
+  const buttonContainer = document.querySelector('div.actions');
 
   if (buttonContainer) {
     const malIdPromise = fetchMalId(anilistId);
     const button = createMALButton(malIdPromise);
     buttonContainer.appendChild(button);
   } else {
-    console.log("Cannot find button container!");
+    console.log('Cannot find button container!');
     if (MAX_RETRIES) {
       MAX_RETRIES--;
       setTimeout(addButton, TIMEOUT);
     } else {
-      throw new Error("Exceeded max retry count!");
+      throw new Error('Exceeded max retry count!');
     }
   }
 }

--- a/src/anilistOverrides/addButton.ts
+++ b/src/anilistOverrides/addButton.ts
@@ -20,7 +20,7 @@ export async function addButton(anilistId: string) {
       MAX_RETRIES--;
       setTimeout(addButton, TIMEOUT);
     } else {
-      console.log("Exceeded max retry count!");
+      throw new Error("Exceeded max retry count!");
     }
   }
 }

--- a/src/anilistOverrides/addButton.ts
+++ b/src/anilistOverrides/addButton.ts
@@ -1,16 +1,26 @@
-import { fetchMalId } from '../api/api';
-import { createMALButton } from '../components/MalButton/button';
+import { fetchMalId } from "../api/api";
+import { createMALButton } from "../components/MalButton/button";
 
 export async function addButton(anilistId: string) {
   // const buttonContainer = document.querySelector(
   //   '#app > div.page-content > div > div.header-wrap > div.header > div > div.cover-wrap.overlap-banner > div > div'
   // );
+  const TIMEOUT = 300;
+  let MAX_RETRIES = 5;
 
-  const buttonContainer = document.querySelector('div.actions');
-  if (!buttonContainer) throw new Error('Cannot find button container!');
+  const buttonContainer = document.querySelector("div.actions");
 
-  const malIdPromise = fetchMalId(anilistId);
-  const button = createMALButton(malIdPromise);
-
-  buttonContainer.appendChild(button);
+  if (buttonContainer) {
+    const malIdPromise = fetchMalId(anilistId);
+    const button = createMALButton(malIdPromise);
+    buttonContainer.appendChild(button);
+  } else {
+    console.log("Cannot find button container!");
+    if (MAX_RETRIES) {
+      MAX_RETRIES--;
+      setTimeout(addButton, TIMEOUT);
+    } else {
+      console.log("Exceeded max retry count!");
+    }
+  }
 }


### PR DESCRIPTION
Sometimes we get an error thrown when the script resolves before the site is fully loaded. This PR adds a few retries so that we are able to have the button added more often, instead of an error being thrown on first try.

The error is more easily reproduced on Anilist entries which were not visited previously (no cached data).